### PR TITLE
Add new pages and sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import Index from "./pages/Index";
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";
 import Verify from "./pages/Verify";
+import AgentBuilder from "./pages/AgentBuilder";
+import AgentEcoSystem from "./pages/AgentEcoSystem";
 
 import AgentDetails from "./pages/AgentDetails";
 import NotFound from "./pages/NotFound";
@@ -25,6 +27,9 @@ const App = () => (
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/verify" element={<Verify />} />
+
+          <Route path="/builder" element={<AgentBuilder />} />
+          <Route path="/ecosystem" element={<AgentEcoSystem />} />
 
           <Route path="/agent/:id" element={<AgentDetails />} />
           <Route path="*" element={<NotFound />} />

--- a/src/components/BookDemoSection.tsx
+++ b/src/components/BookDemoSection.tsx
@@ -1,0 +1,35 @@
+import { useState, FormEvent } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+const BookDemoSection = () => {
+  const [email, setEmail] = useState('');
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    window.location.href = `mailto:info@nouscloud.tech?subject=Demo%20Request&body=${encodeURIComponent(email)}`;
+    setSent(true);
+  };
+
+  return (
+    <section className="py-12 bg-gray-50">
+      <div className="container mx-auto px-4 text-center">
+        <h2 className="text-3xl font-bold mb-4">Book a Demo</h2>
+        <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row max-w-md mx-auto gap-2">
+          <Input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+          <Button type="submit">Schedule Demo</Button>
+        </form>
+        {sent && <p className="mt-4 text-green-600">Thanks! We'll reach out soon.</p>}
+      </div>
+    </section>
+  );
+};
+
+export default BookDemoSection;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -24,6 +24,12 @@ const Navbar = () => {
             <Button variant="ghost" asChild className="hidden md:inline-flex">
               <Link to="/about">About</Link>
             </Button>
+            <Button variant="ghost" asChild className="hidden md:inline-flex">
+              <Link to="/builder">AgentBuilder</Link>
+            </Button>
+            <Button variant="ghost" asChild className="hidden md:inline-flex">
+              <Link to="/ecosystem">Ecosystem</Link>
+            </Button>
 
             {isAuthenticated ? (
               <Button variant="outline" onClick={logout} className="flex items-center space-x-2">

--- a/src/components/UseCasesSection.tsx
+++ b/src/components/UseCasesSection.tsx
@@ -1,0 +1,24 @@
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import { useCases } from '@/data/useCases';
+
+const UseCasesSection = () => (
+  <section className="py-12">
+    <div className="container mx-auto px-4">
+      <h2 className="text-3xl font-bold text-center mb-6">Agent Use Cases</h2>
+      <Accordion type="multiple" className="grid md:grid-cols-2 gap-4">
+        {useCases.map(uc => (
+          <AccordionItem key={uc.title} value={uc.title} className="border rounded-md">
+            <AccordionTrigger className="p-4 font-medium bg-gray-100">
+              {uc.title}
+            </AccordionTrigger>
+            <AccordionContent className="p-4 bg-white">
+              {uc.description}
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </div>
+  </section>
+);
+
+export default UseCasesSection;

--- a/src/data/useCases.ts
+++ b/src/data/useCases.ts
@@ -1,0 +1,39 @@
+export interface UseCase {
+  title: string;
+  description: string;
+}
+
+export const useCases: UseCase[] = [
+  {
+    title: 'Customer Service',
+    description: 'Automate support responses and handle FAQs to improve customer satisfaction.'
+  },
+  {
+    title: 'Sales',
+    description: 'Generate leads and assist prospects throughout the sales funnel.'
+  },
+  {
+    title: 'Marketing',
+    description: 'Personalize campaigns, analyze trends and engage audiences.'
+  },
+  {
+    title: 'HR',
+    description: 'Streamline recruitment, onboarding and employee support tasks.'
+  },
+  {
+    title: 'Finance',
+    description: 'Automate invoicing, reporting and forecasting processes.'
+  },
+  {
+    title: 'Education',
+    description: 'Deliver personalized tutoring and manage classroom interactions.'
+  },
+  {
+    title: 'Travel',
+    description: 'Plan itineraries, manage bookings and provide real-time assistance.'
+  },
+  {
+    title: 'Legal',
+    description: 'Draft documents, review contracts and research regulations.'
+  }
+];

--- a/src/pages/AgentBuilder.tsx
+++ b/src/pages/AgentBuilder.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import Navbar from '@/components/Navbar';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+const AgentBuilder = () => {
+  const [email, setEmail] = useState('');
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSent(true);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50">
+      <Navbar />
+      <div className="container mx-auto px-4 py-20 text-center">
+        <h1 className="text-4xl font-bold mb-6">Connect with us</h1>
+        <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row max-w-md mx-auto gap-2">
+          <Input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+          <Button type="submit">Send</Button>
+        </form>
+        {sent && <p className="mt-4 text-green-600">Thanks! We'll reach out soon.</p>}
+      </div>
+    </div>
+  );
+};
+
+export default AgentBuilder;

--- a/src/pages/AgentEcoSystem.tsx
+++ b/src/pages/AgentEcoSystem.tsx
@@ -1,0 +1,51 @@
+import Navbar from '@/components/Navbar';
+
+const tools = [
+  'Zapier',
+  'Slack',
+  'Notion',
+  'Google Workspace'
+];
+
+const platforms = [
+  'AWS',
+  'Azure',
+  'GCP'
+];
+
+const integrations = [
+  'CRM Systems',
+  'Data Warehouses',
+  'Messaging Apps'
+];
+
+const AgentEcoSystem = () => (
+  <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50">
+    <Navbar />
+    <div className="container mx-auto px-4 py-20">
+      <h1 className="text-4xl font-bold text-center mb-8">Agent Ecosystem</h1>
+      <div className="grid md:grid-cols-3 gap-8">
+        <div className="bg-white p-6 rounded-lg shadow">
+          <h2 className="text-2xl font-semibold mb-4">Tools</h2>
+          <ul className="list-disc list-inside space-y-1">
+            {tools.map(t => <li key={t}>{t}</li>)}
+          </ul>
+        </div>
+        <div className="bg-white p-6 rounded-lg shadow">
+          <h2 className="text-2xl font-semibold mb-4">Platforms</h2>
+          <ul className="list-disc list-inside space-y-1">
+            {platforms.map(p => <li key={p}>{p}</li>)}
+          </ul>
+        </div>
+        <div className="bg-white p-6 rounded-lg shadow">
+          <h2 className="text-2xl font-semibold mb-4">Integrations</h2>
+          <ul className="list-disc list-inside space-y-1">
+            {integrations.map(i => <li key={i}>{i}</li>)}
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default AgentEcoSystem;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,8 @@ import Navbar from '@/components/Navbar';
 import Hero from '@/components/Hero';
 import AgentGrid from '@/components/AgentGrid';
 import SearchAndFilter from '@/components/SearchAndFilter';
+import UseCasesSection from '@/components/UseCasesSection';
+import BookDemoSection from '@/components/BookDemoSection';
 import { Agent } from '@/types/agent';
 import { fetchAgents } from '@/utils/api';
 
@@ -51,6 +53,8 @@ const Index = () => {
         />
         <AgentGrid agents={filteredAgents} />
       </div>
+      <UseCasesSection />
+      <BookDemoSection />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add pages for AgentBuilder and AgentEcoSystem
- create Agent Use Cases data and section
- add Book a Demo section with mailto link
- update Index page to display new sections
- expose new pages through navbar and router

## Testing
- `npm install`
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68623af86dbc832aa8fb4323c00b3781