### PR TITLE
Add local agents list and reorder demo section

### DIFF
--- a/public/agents.json
+++ b/public/agents.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "1",
+    "name": "DataViz Pro",
+    "description": "Advanced data visualization agent that creates stunning charts and dashboards from your raw data automatically.",
+    "category": "Data Analysis",
+    "price": 29,
+    "rating": 4.8,
+    "users": 1250,
+    "runtime": "Python 3.9",
+    "author": "DataTech Solutions",
+    "tags": ["visualization", "charts", "analytics", "dashboard"],
+    "features": [
+      "Automatic chart generation",
+      "Interactive dashboards",
+      "Real-time data processing",
+      "Export to multiple formats"
+    ],
+    "documentation": "Complete API documentation and usage examples included."
+  },
+  {
+    "id": "2",
+    "name": "ChatBot Assistant",
+    "description": "Intelligent customer service chatbot with natural language processing and multilingual support.",
+    "category": "Customer Service",
+    "price": 49,
+    "rating": 4.9,
+    "users": 2100,
+    "runtime": "Node.js 18",
+    "author": "AI Support Inc",
+    "tags": ["chatbot", "nlp", "customer-service", "multilingual"],
+    "features": [
+      "24/7 customer support",
+      "Multilingual capabilities",
+      "Integration with CRM systems",
+      "Sentiment analysis"
+    ],
+    "documentation": "Comprehensive setup guide with integration examples."
+  },
+  {
+    "id": "3",
+    "name": "Content Creator",
+    "description": "AI-powered content generation agent for blogs, social media, and marketing materials.",
+    "category": "Content Creation",
+    "price": 39,
+    "rating": 4.7,
+    "users": 890,
+    "runtime": "Python 3.9",
+    "author": "ContentAI Labs",
+    "tags": ["content", "writing", "marketing", "seo"],
+    "features": [
+      "SEO-optimized content",
+      "Multiple content formats",
+      "Brand voice consistency",
+      "Plagiarism detection"
+    ],
+    "documentation": "Step-by-step tutorials and best practices guide."
+  },
+  {
+    "id": "4",
+    "name": "Email Marketing Bot",
+    "description": "Automated email marketing campaigns with personalization and A/B testing capabilities.",
+    "category": "Marketing",
+    "price": 59,
+    "rating": 4.6,
+    "users": 675,
+    "runtime": "Node.js 18",
+    "author": "MarketFlow Pro",
+    "tags": ["email", "marketing", "automation", "personalization"],
+    "features": [
+      "Campaign automation",
+      "A/B testing",
+      "Personalization engine",
+      "Analytics dashboard"
+    ],
+    "documentation": "Complete integration guide with API reference."
+  },
+  {
+    "id": "5",
+    "name": "Code Review Assistant",
+    "description": "Automated code review and quality analysis agent for multiple programming languages.",
+    "category": "Development",
+    "price": 79,
+    "rating": 4.9,
+    "users": 1450,
+    "runtime": "Docker",
+    "author": "DevTools United",
+    "tags": ["code-review", "quality", "development", "automation"],
+    "features": [
+      "Multi-language support",
+      "Security vulnerability detection",
+      "Code quality metrics",
+      "CI/CD integration"
+    ],
+    "documentation": "Developer documentation with integration examples."
+  },
+  {
+    "id": "6",
+    "name": "Financial Analyzer",
+    "description": "Advanced financial data analysis and reporting agent with predictive modeling capabilities.",
+    "category": "Finance",
+    "price": 99,
+    "rating": 4.8,
+    "users": 540,
+    "runtime": "Python 3.9",
+    "author": "FinTech Analytics",
+    "tags": ["finance", "analysis", "predictive", "reporting"],
+    "features": [
+      "Predictive modeling",
+      "Risk assessment",
+      "Automated reporting",
+      "Real-time market data"
+    ],
+    "documentation": "Financial API documentation and compliance guide."
+  }
+]

--- a/src/data/useCases.ts
+++ b/src/data/useCases.ts
@@ -35,5 +35,21 @@ export const useCases: UseCase[] = [
   {
     title: 'Legal',
     description: 'Draft documents, review contracts and research regulations.'
+  },
+  {
+    title: 'Healthcare',
+    description: 'Assist with patient triage, medical data analysis and health advice.'
+  },
+  {
+    title: 'Real Estate',
+    description: 'Automate property listings, client interactions and market research.'
+  },
+  {
+    title: 'Manufacturing',
+    description: 'Optimize production schedules and monitor quality control.'
+  },
+  {
+    title: 'Retail',
+    description: 'Manage inventory, personalize shopping experiences and analyze sales trends.'
   }
 ];

--- a/src/pages/AgentsDirectory.tsx
+++ b/src/pages/AgentsDirectory.tsx
@@ -2,22 +2,25 @@ import { useEffect, useState } from 'react';
 import Navbar from '@/components/Navbar';
 import AgentGrid from '@/components/AgentGrid';
 import SearchAndFilter from '@/components/SearchAndFilter';
+import BookDemoSection from '@/components/BookDemoSection';
 import { Agent } from '@/types/agent';
-import { fetchAgents } from '@/utils/api';
 
 const AgentsDirectory = () => {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('All');
 
+  const AGENTS_URL = import.meta.env.VITE_AGENTS_URL || '/agents.json';
+
   useEffect(() => {
     const loadAgents = async () => {
       try {
-        const res = await fetchAgents();
-        setAgents(res.data);
+        const res = await fetch(AGENTS_URL);
+        if (!res.ok) throw new Error('Network error');
+        const data: Agent[] = await res.json();
+        setAgents(data);
       } catch (err) {
-        console.error('Error fetching agents:', err);
-        alert('Failed to load agents');
+        console.error('Error loading agents:', err);
       }
     };
     loadAgents();
@@ -47,6 +50,7 @@ const AgentsDirectory = () => {
         />
         <AgentGrid agents={filteredAgents} />
       </div>
+      <BookDemoSection />
     </div>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -52,9 +52,9 @@ const Index = () => {
           setSelectedCategory={setSelectedCategory}
         />
         <AgentGrid agents={filteredAgents} />
+        <BookDemoSection />
       </div>
       <UseCasesSection />
-      <BookDemoSection />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- fetch agents from configurable `agents.json` and add demo section to Browse page
- move Book Demo section below Explore Agents on home page
- expand use case examples
- add static `public/agents.json`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686240dad2e0832ab7d1150e66d9091b