### PR TITLE
Remove agent price and stats on Browse Agents page

### DIFF
--- a/src/components/AgentCard.tsx
+++ b/src/components/AgentCard.tsx
@@ -8,9 +8,10 @@ import { Play, Star, Users } from 'lucide-react';
 interface AgentCardProps {
   agent: Agent;
   onRun?: () => void; // 👈 optional handler for Run button
+  hideMeta?: boolean; // hide price, rating and users when true
 }
 
-const AgentCard = ({ agent, onRun }: AgentCardProps) => {
+const AgentCard = ({ agent, onRun, hideMeta = false }: AgentCardProps) => {
   return (
     <Card className="agent-card-hover h-full flex flex-col">
       <CardHeader>
@@ -29,22 +30,26 @@ const AgentCard = ({ agent, onRun }: AgentCardProps) => {
       </CardHeader>
 
       <CardContent className="flex-1">
-        <div className="flex items-center gap-4 text-sm text-gray-600 mb-4">
-          <div className="flex items-center gap-1">
-            <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
-            <span>{agent.rating}</span>
+        {!hideMeta && (
+          <div className="flex items-center gap-4 text-sm text-gray-600 mb-4">
+            <div className="flex items-center gap-1">
+              <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+              <span>{agent.rating}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Users className="h-4 w-4" />
+              <span>{agent.users} users</span>
+            </div>
           </div>
-          <div className="flex items-center gap-1">
-            <Users className="h-4 w-4" />
-            <span>{agent.users} users</span>
-          </div>
-        </div>
+        )}
 
         <div className="space-y-2">
-          <div className="text-sm">
-            <span className="font-medium">Price: </span>
-            <span className="text-green-600 font-semibold">${agent.price}/month</span>
-          </div>
+          {!hideMeta && (
+            <div className="text-sm">
+              <span className="font-medium">Price: </span>
+              <span className="text-green-600 font-semibold">${agent.price}/month</span>
+            </div>
+          )}
           <div className="text-sm">
             <span className="font-medium">Runtime: </span>
             <span>{agent.runtime}</span>

--- a/src/components/AgentGrid.tsx
+++ b/src/components/AgentGrid.tsx
@@ -4,9 +4,10 @@ import { runAgent } from '@/utils/api';
 
 interface AgentGridProps {
   agents: Agent[];
+  hideMeta?: boolean; // hide price, rating and user stats for each card
 }
 
-const AgentGrid = ({ agents }: AgentGridProps) => {
+const AgentGrid = ({ agents, hideMeta = false }: AgentGridProps) => {
   const handleRun = async (id: string) => {
     try {
       await runAgent(id);
@@ -20,7 +21,12 @@ const AgentGrid = ({ agents }: AgentGridProps) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       {agents.map(agent => (
-        <AgentCard key={agent.id} agent={agent} onRun={() => handleRun(agent.id)} />
+        <AgentCard
+          key={agent.id}
+          agent={agent}
+          onRun={() => handleRun(agent.id)}
+          hideMeta={hideMeta}
+        />
       ))}
     </div>
   );

--- a/src/pages/AgentsDirectory.tsx
+++ b/src/pages/AgentsDirectory.tsx
@@ -48,7 +48,7 @@ const AgentsDirectory = () => {
           selectedCategory={selectedCategory}
           setSelectedCategory={setSelectedCategory}
         />
-        <AgentGrid agents={filteredAgents} />
+        <AgentGrid agents={filteredAgents} hideMeta />
       </div>
       <BookDemoSection />
     </div>


### PR DESCRIPTION
## Summary
- add optional `hideMeta` prop to `AgentCard`
- allow `AgentGrid` to forward `hideMeta` to each card
- hide price, rating and users in `AgentsDirectory`

## Testing
- `npm run lint` *(fails: no-empty-object-type errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686292c74564832a8f201d909b998004