### PR TITLE
Enhance use case section with CSV data

### DIFF
--- a/src/components/UseCasesSection.tsx
+++ b/src/components/UseCasesSection.tsx
@@ -1,24 +1,79 @@
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
-import { useCases } from '@/data/useCases';
+import { useMemo } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import csvData from '@/data/Agent_usecases.csv?raw';
+import { parseCsv } from '@/utils/parseCsv';
 
-const UseCasesSection = () => (
-  <section className="py-12">
-    <div className="container mx-auto px-4">
-      <h2 className="text-3xl font-bold text-center mb-6">Agent Use Cases</h2>
-      <Accordion type="multiple" className="grid md:grid-cols-2 gap-4">
-        {useCases.map(uc => (
-          <AccordionItem key={uc.title} value={uc.title} className="border rounded-md">
-            <AccordionTrigger className="p-4 font-medium bg-gray-100">
-              {uc.title}
-            </AccordionTrigger>
-            <AccordionContent className="p-4 bg-white">
-              {uc.description}
-            </AccordionContent>
-          </AccordionItem>
-        ))}
-      </Accordion>
-    </div>
-  </section>
-);
+interface AgentUseCase {
+  Category: string;
+  'Agent Name': string;
+  Description: string;
+  Complexity: string;
+  Instant: string;
+  'Demo Readiness': string;
+  'Go-Live Time': string;
+}
+
+const UseCasesSection = () => {
+  const grouped = useMemo(() => {
+    const records = parseCsv(csvData) as AgentUseCase[];
+    return records.reduce<Record<string, AgentUseCase[]>>((acc, rec) => {
+      if (!acc[rec.Category]) acc[rec.Category] = [];
+      acc[rec.Category].push(rec);
+      return acc;
+    }, {});
+  }, []);
+
+  const categories = Object.keys(grouped);
+
+  if (categories.length === 0) return null;
+
+  return (
+    <section className="py-12 bg-gray-50">
+      <div className="container mx-auto px-4">
+        <h2 className="text-3xl font-bold text-center mb-6">Agent Use Cases</h2>
+        <Tabs defaultValue={categories[0]} className="w-full">
+          <TabsList className="flex flex-wrap justify-center gap-2 mb-6">
+            {categories.map(cat => (
+              <TabsTrigger key={cat} value={cat} className="capitalize">
+                {cat}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          {categories.map(cat => (
+            <TabsContent key={cat} value={cat} className="outline-none">
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {grouped[cat].map(uc => (
+                  <Card key={uc['Agent Name']} className="h-full">
+                    <CardHeader>
+                      <CardTitle className="text-lg">{uc['Agent Name']}</CardTitle>
+                      <CardDescription>{uc.Description}</CardDescription>
+                    </CardHeader>
+                    <CardContent className="text-sm space-y-1">
+                      <p>
+                        <span className="font-medium">Complexity:</span> {uc.Complexity}
+                      </p>
+                      <p>
+                        <span className="font-medium">Instant:</span> {uc.Instant}
+                      </p>
+                      {uc['Demo Readiness'] && (
+                        <p>
+                          <span className="font-medium">Demo Ready:</span> {uc['Demo Readiness']}
+                        </p>
+                      )}
+                      <p>
+                        <span className="font-medium">Go-Live Time:</span> {uc['Go-Live Time']}
+                      </p>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </TabsContent>
+          ))}
+        </Tabs>
+      </div>
+    </section>
+  );
+};
 
 export default UseCasesSection;

--- a/src/utils/parseCsv.ts
+++ b/src/utils/parseCsv.ts
@@ -1,0 +1,46 @@
+export interface CsvRecord {
+  [key: string]: string;
+}
+
+export function parseCsv(csv: string): CsvRecord[] {
+  const lines = csv.trim().split(/\r?\n/);
+  if (lines.length === 0) return [];
+  const headers = splitRow(lines[0]);
+  const records: CsvRecord[] = [];
+
+  for (const line of lines.slice(1)) {
+    const values = splitRow(line);
+    const record: CsvRecord = {};
+    headers.forEach((h, idx) => {
+      record[h.trim()] = values[idx] ? values[idx].trim() : '';
+    });
+    records.push(record);
+  }
+  return records;
+}
+
+function splitRow(row: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < row.length; i++) {
+    const char = row[i];
+
+    if (char === '"') {
+      if (inQuotes && row[i + 1] === '"') {
+        current += '"';
+        i++; // skip escaped quote
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  result.push(current);
+  return result;
+}


### PR DESCRIPTION
## Summary
- add a CSV parser utility
- redraw the UseCasesSection using data from `Agent_usecases.csv`

## Testing
- `npm run lint` *(fails: several pre-existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6862a1d1b92c832ab307c6370ab70edb