### PR TITLE
Integrate SendMail API with reCAPTCHA

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 VITE_API_BASE=/api
+VITE_RECAPTCHA_SITE_KEY=your_site_key

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 VITE_API_BASE=https://xtbfbopxac.execute-api.ap-south-1.amazonaws.com/prod
+VITE_RECAPTCHA_SITE_KEY=your_site_key

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
 
   <body>
     <div id="root"></div>
+    <script src="https://www.google.com/recaptcha/api.js?render=%VITE_RECAPTCHA_SITE_KEY%"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/BookDemoSection.tsx
+++ b/src/components/BookDemoSection.tsx
@@ -2,14 +2,59 @@ import { useState, FormEvent } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 
+declare const grecaptcha: any;
+
+const SITE_KEY = import.meta.env.VITE_RECAPTCHA_SITE_KEY || '<SITE_KEY>';
+const API_URL =
+  'https://5zt0gybyx1.execute-api.ap-south-1.amazonaws.com/send';
+const API_KEY = 'DWNWK4r9jO10yqWZJDV6g4V1DwnOUKWm8FEw0Qyu';
+const RATE_LIMIT_MS = 10000;
+
 const BookDemoSection = () => {
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    window.location.href = `mailto:info@nouscloud.tech?subject=Demo%20Request&body=${encodeURIComponent(email)}`;
-    setSent(true);
+
+    const last = Number(localStorage.getItem('lastEmailTime'));
+    if (Date.now() - last < RATE_LIMIT_MS) {
+      alert('Please wait before sending another request.');
+      return;
+    }
+
+    grecaptcha.ready(() => {
+      setLoading(true);
+      grecaptcha
+        .execute(SITE_KEY, { action: 'submit' })
+        .then((token: string) => sendEmail(token));
+    });
+  };
+
+  const sendEmail = (token: string) => {
+    const payload = {
+      to: 'info@nouscloud.tech',
+      subject: 'Demo Request',
+      text: email,
+      recaptchaToken: token,
+    };
+
+    fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': API_KEY,
+      },
+      body: JSON.stringify(payload),
+    })
+      .then(res => res.json())
+      .then(() => {
+        setSent(true);
+        localStorage.setItem('lastEmailTime', Date.now().toString());
+      })
+      .catch(() => alert('Failed to send message'))
+      .finally(() => setLoading(false));
   };
 
   return (
@@ -24,7 +69,9 @@ const BookDemoSection = () => {
             onChange={e => setEmail(e.target.value)}
             required
           />
-          <Button type="submit">Schedule Demo</Button>
+          <Button type="submit" disabled={loading}>
+            {loading ? 'Sending...' : 'Schedule Demo'}
+          </Button>
         </form>
         {sent && <p className="mt-4 text-green-600">Thanks! We'll reach out soon.</p>}
       </div>

--- a/src/pages/AgentBuilder.tsx
+++ b/src/pages/AgentBuilder.tsx
@@ -3,13 +3,59 @@ import Navbar from '@/components/Navbar';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 
+declare const grecaptcha: any;
+
+const SITE_KEY = import.meta.env.VITE_RECAPTCHA_SITE_KEY || '<SITE_KEY>';
+const API_URL =
+  'https://5zt0gybyx1.execute-api.ap-south-1.amazonaws.com/send';
+const API_KEY = 'DWNWK4r9jO10yqWZJDV6g4V1DwnOUKWm8FEw0Qyu';
+const RATE_LIMIT_MS = 10000;
+
 const AgentBuilder = () => {
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    setSent(true);
+
+    const last = Number(localStorage.getItem('lastEmailTime'));
+    if (Date.now() - last < RATE_LIMIT_MS) {
+      alert('Please wait before sending another request.');
+      return;
+    }
+
+    grecaptcha.ready(() => {
+      setLoading(true);
+      grecaptcha
+        .execute(SITE_KEY, { action: 'submit' })
+        .then((token: string) => sendEmail(token));
+    });
+  };
+
+  const sendEmail = (token: string) => {
+    const payload = {
+      to: 'info@nouscloud.tech',
+      subject: 'Contact Request',
+      text: email,
+      recaptchaToken: token,
+    };
+
+    fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': API_KEY,
+      },
+      body: JSON.stringify(payload),
+    })
+      .then(res => res.json())
+      .then(() => {
+        setSent(true);
+        localStorage.setItem('lastEmailTime', Date.now().toString());
+      })
+      .catch(() => alert('Failed to send message'))
+      .finally(() => setLoading(false));
   };
 
   return (
@@ -25,7 +71,9 @@ const AgentBuilder = () => {
             onChange={e => setEmail(e.target.value)}
             required
           />
-          <Button type="submit">Send</Button>
+          <Button type="submit" disabled={loading}>
+            {loading ? 'Sending...' : 'Send'}
+          </Button>
         </form>
         {sent && <p className="mt-4 text-green-600">Thanks! We'll reach out soon.</p>}
       </div>


### PR DESCRIPTION
## Summary
- add Google reCAPTCHA script to the HTML entry
- wire demo and contact forms to AWS SendMail API
- implement basic rate limiting and loading states for forms
- expose `VITE_RECAPTCHA_SITE_KEY` in env files

## Testing
- `npm run lint` *(fails: no-explicit-any and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_686932f9c198832aa8a465845bc0435b