### PR TITLE
Fix stuck state when booking a demo

### DIFF
--- a/src/components/BookDemoSection.tsx
+++ b/src/components/BookDemoSection.tsx
@@ -27,11 +27,15 @@ const BookDemoSection = () => {
       return;
     }
 
-    grecaptcha.ready(() => {
+    grecaptcha.ready(async () => {
       setLoading(true);
-      grecaptcha
-        .execute(SITE_KEY, { action: 'submit' })
-        .then((token: string) => sendEmail(token));
+      try {
+        const token = await grecaptcha.execute(SITE_KEY, { action: 'submit' });
+        sendEmail(token);
+      } catch (err) {
+        alert('Failed to verify reCAPTCHA');
+        setLoading(false);
+      }
     });
   };
 

--- a/src/pages/AgentBuilder.tsx
+++ b/src/pages/AgentBuilder.tsx
@@ -25,11 +25,15 @@ const AgentBuilder = () => {
       return;
     }
 
-    grecaptcha.ready(() => {
+    grecaptcha.ready(async () => {
       setLoading(true);
-      grecaptcha
-        .execute(SITE_KEY, { action: 'submit' })
-        .then((token: string) => sendEmail(token));
+      try {
+        const token = await grecaptcha.execute(SITE_KEY, { action: 'submit' });
+        sendEmail(token);
+      } catch (err) {
+        alert('Failed to verify reCAPTCHA');
+        setLoading(false);
+      }
     });
   };
 


### PR DESCRIPTION
## Summary
- handle reCAPTCHA failures so loading state resets

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68693ad98f08832a9ba807206c2def4e