### PR TITLE
Improve email success detection

### DIFF
--- a/src/components/BookDemoSection.tsx
+++ b/src/components/BookDemoSection.tsx
@@ -58,13 +58,20 @@ const BookDemoSection = () => {
         let data;
         try {
           data = await res.json();
-        } catch (e) {
+        } catch {
           data = null;
         }
-        if (
-          (data && data.message && data.message.toLowerCase().includes('success')) ||
-          res.ok
-        ) {
+
+        const success =
+          res.ok ||
+          (data &&
+            ((typeof data.success === 'boolean' && data.success) ||
+              (typeof data.status === 'string' &&
+                data.status.toLowerCase() === 'success') ||
+              (typeof data.message === 'string' &&
+                /success|sent/i.test(data.message))));
+
+        if (success) {
           alert('Successfully sent message');
           setSent(true);
           setName('');

--- a/src/pages/AgentBuilder.tsx
+++ b/src/pages/AgentBuilder.tsx
@@ -58,10 +58,20 @@ const AgentBuilder = () => {
         let data;
         try {
           data = await res.json();
-        } catch (e) {
+        } catch {
           data = null;
         }
-        if (res.ok || (data && data.message && data.message.toLowerCase().includes('success'))) {
+
+        const success =
+          res.ok ||
+          (data &&
+            ((typeof data.success === 'boolean' && data.success) ||
+              (typeof data.status === 'string' &&
+                data.status.toLowerCase() === 'success') ||
+              (typeof data.message === 'string' &&
+                /success|sent/i.test(data.message))));
+
+        if (success) {
           alert('Successfully sent message');
           setSent2(true);
           setName2('');


### PR DESCRIPTION
## Summary
- broaden success detection for email send API calls
- use new check in BookDemoSection and AgentBuilder

## Testing
- `npm run lint` *(fails: no-empty-object-type, unexpected any, and other errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68695e3f1090832aae1344accadc7f49